### PR TITLE
Correcting for errors introduced by Hugo 0.141

### DIFF
--- a/.changeset/nice-lies-repeat.md
+++ b/.changeset/nice-lies-repeat.md
@@ -1,0 +1,5 @@
+---
+"@thulite/images": patch
+---
+
+Correcting for errors introduced by Hugo 0.141

--- a/layouts/_default/_markup/render-image.html
+++ b/layouts/_default/_markup/render-image.html
@@ -104,14 +104,14 @@ partial template, after the render hook has captured the resource.
 {{- /* Get image resource. */}}
 {{- $r := "" }}
 {{- if $u.IsAbs }}
-  {{- with resources.GetRemote $u.String }}
+  {{- with try (resources.GetRemote $u.String) }}
     {{- with .Err }}
       {{- if eq $errorLevel "warning" }}
-        {{- warnf "%s. See %s" . $contentPath }}
+        {{- warnf "%s. See %s" .Err $contentPath }}
       {{- else if eq $errorLevel "error" }}
-        {{- errorf "%s. See %s" . $contentPath }}
+        {{- errorf "%s. See %s" .Err $contentPath }}
       {{- end }}
-    {{- else }}
+    {{- else with .Value }}
       {{- /* Destination is a remote resource. */}}
       {{- $r = . }}
     {{- end }}

--- a/layouts/partials/figure.html
+++ b/layouts/partials/figure.html
@@ -257,10 +257,10 @@ Add this CSS to your site to remove small gaps between adjacent elements:
   {{- /* Get image resource. */}}
   {{- $r := "" }}
   {{- if $u.IsAbs }}
-    {{- with resources.GetRemote $u.String }}
+    {{- with try (resources.GetRemote $u.String) }}
       {{- with .Err }}
-        {{- errorf "%s. See %s" . $.contentPath }}
-      {{- else }}
+        {{- errorf "%s. See %s" .Err $.contentPath }}
+      {{- else with .Value }}
         {{- /* Destination is a remote resource. */}}
         {{- $r = . }}
       {{- end }}

--- a/layouts/partials/img.html
+++ b/layouts/partials/img.html
@@ -251,12 +251,12 @@ Add this CSS to your site to remove small gaps between adjacent elements:
   {{- /* Get image resource. */}}
   {{- $r := "" }}
   {{- if $u.IsAbs }}
-    {{- with resources.GetRemote $u.String }}
+    {{- with try (resources.GetRemote $u.String) }}
       {{- with .Err }}
-        {{- errorf "%s. See %s" . $.contentPath }}
-      {{- else }}
+        {{- errorf "%s. See %s" .Err $.contentPath }}
+      {{- else with .Value }}
         {{- /* Destination is a remote resource. */}}
-        {{- $r = . }}
+        {{- $r = .Value }}
       {{- end }}
     {{- else }}
       {{- errorf $msg }}

--- a/layouts/partials/picture.html
+++ b/layouts/partials/picture.html
@@ -253,10 +253,10 @@ Add this CSS to your site to remove small gaps between adjacent elements:
   {{- /* Get image resource. */}}
   {{- $r := "" }}
   {{- if $u.IsAbs }}
-    {{- with resources.GetRemote $u.String }}
+    {{- with try (resources.GetRemote $u.String) }}
       {{- with .Err }}
-        {{- errorf "%s. See %s" . $.contentPath }}
-      {{- else }}
+        {{- errorf "%s. See %s" .Err $.contentPath }}
+      {{- else with .Value }}
         {{- /* Destination is a remote resource. */}}
         {{- $r = . }}
       {{- end }}


### PR DESCRIPTION
## Summary

Hugo 0.141 introduced the following error in Thulite Images:

can't evaluate field Err in type resource.Resource: Resource.Err was removed in Hugo v0.141.0 and replaced with a new try keyword, see https://gohugo.io/functions/go-template/try/

I corrected the syntax as instructed in the Hugo docs inside 4 partials within Thulite Images.

## Basic example

Essentially this change, with slight variations, in 4 partials:

From:

  {{- with resources.GetRemote $u.String }}
      {{- with .Err }}
        {{- errorf "%s. See %s" . $.contentPath }}
      {{- else }}
        {{- /* Destination is a remote resource. */}}
        {{- $r = . }}

To this:

{{- with try (resources.GetRemote $u.String) }}
      {{- with .Err }}
        {{- errorf "%s. See %s" .Err $.contentPath }}
      {{- else with .Value }}
        {{- /* Destination is a remote resource. */}}
        {{- $r = .Value }}

## Motivation

More recent versions of Hugo break Thulite Images. 

## Checks

- [ ] Read [Creating a pull request](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request)
- [ ] Supports all screen sizes (if relevant)
- [ ] Supports both light and dark mode (if relevant)
- [ ] Passes `npm run test` (if relevant)
